### PR TITLE
Including PHP build information on before_script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
 
 # execute any number of scripts before the test run, custom env's are available as variables
 before_script:
+  - php -i
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS hello_world_test;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'create database hello_world_test;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'create database IF NOT EXISTS hello_world_test;' -uroot; fi"


### PR DESCRIPTION
Since there is no place (that I know of) that contains this information, keeping it on a build makes sense.
