### PR TITLE
Add update badge message to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ Here is a sample status icon showing the state of the master branch.
 
 In order to run this project just fork it on github.com and then [enable](http://about.travis-ci.org/docs/user/getting-started/)
 your fork on your [travis-ci profile](http://travis-ci.org/profile). Every push will then trigger a new build on Travis CI.
+
+(Don't forget to update the badge url in the README to point to your own travis project.)


### PR DESCRIPTION
This caught me for a bit, couldn't figure out why the badge wasn't updating my own Github project page and kept linking me to the original travis-ci/travis-ci-php-example project, thought I'd save someone else a few minutes :)

...also first ever pull request, forgive me if I've got it all wrong!
