### PR TITLE
Updated the php 5.3 comment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
 
   # aliased to 5.2.17
   - 5.2
-  # aliased to a recent 5.3.x version
+  # aliased to 5.3.29
   - 5.3
   # aliased to a recent 5.4.x version
   - 5.4


### PR DESCRIPTION
PHP 5.3.29 is the last 5.3.x release, so we might as well name it like we did for php 5.2.17.
