### PR TITLE
Default to PHP versions under active development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,18 @@ language: php
 php:
   # using major version aliases
 
-  # aliased to 5.2.17
-  - 5.2
-  # aliased to 5.3.29
-  - 5.3
-  # aliased to a recent 5.4.x version
-  - 5.4
   # aliased to a recent 5.5.x version
   - 5.5
   # aliased to a recent 5.6.x version
   - 5.6
-  # aliased to a recent 7.x version
+  # aliased to a recent 7.0.x version
   - 7.0
+  # aliased to a recent 7.1.x version
+  - 7.1
+  # aliased to a recent 7.2.x version
+  - 7.2
+  # aliased to a recent nightly build
+  - nightly
   # aliased to a recent hhvm version
   - hhvm
 
@@ -31,7 +31,7 @@ matrix:
     - php: hhvm
       env: DB=pgsql  # PDO driver for pgsql is unsupported by HHVM (3rd party install for support)
   allow_failures:
-    - php: 7.0
+    - php: 5.5
     - php: hhvm
 
 # execute any number of scripts before the test run, custom env's are available as variables

--- a/Tests/HelloWorldTest.php
+++ b/Tests/HelloWorldTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class HelloWorldTest extends PHPUnit_Framework_TestCase
+class HelloWorldTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var PDO
@@ -44,4 +44,3 @@ class HelloWorldTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Bar', $helloWorld->what());
     }
 }
-

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -2,6 +2,12 @@
 
 function loader($class)
 {
+    // Support for pre-PHP 5.6 versions
+    if ($class === 'PHPUnit\Framework\TestCase') {
+      class_alias('PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
+
+      return;
+    }
     $file = $class . '.php';
     if (file_exists($file)) {
         require $file;


### PR DESCRIPTION
PHP 7.0 is no longer under active support, and PHP 5.5 has been End of Life since Jul 2016.
This commit removes version 5.2 - 5.4, and allows failure on EoL 5.5.
It also adds 7.1, 7.2, and nightly, in an attempt to promote newer versions of PHP.