### PR TITLE
Fixes to pass build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ language: php
 php:
   # using major version aliases
 
-  # aliased to a recent 5.5.x version
-  #- 5.5
   # aliased to a recent 5.6.x version
   - 5.6
   # aliased to a recent 7.0.x version

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,18 @@ language: php
 php:
   # using major version aliases
 
-  # aliased to 5.2.17
-  - 5.2
-  # aliased to 5.3.29
-  - 5.3
-  # aliased to a recent 5.4.x version
-  - 5.4
   # aliased to a recent 5.5.x version
   - 5.5
   # aliased to a recent 5.6.x version
   - 5.6
-  # aliased to a recent 7.x version
+  # aliased to a recent 7.0.x version
   - 7.0
+  # aliased to a recent 7.1.x version
+  - 7.1
+  # aliased to a recent 7.2.x version
+  - 7.2
+  # aliased to a recent nightly build
+  - nightly
   # aliased to a recent hhvm version
   - hhvm
 
@@ -31,7 +31,7 @@ matrix:
     - php: hhvm
       env: DB=pgsql  # PDO driver for pgsql is unsupported by HHVM (3rd party install for support)
   allow_failures:
-    - php: 7.0
+    - php: 5.5
     - php: hhvm
 
 # execute any number of scripts before the test run, custom env's are available as variables

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   # using major version aliases
 
   # aliased to a recent 5.5.x version
-  - 5.5
+  #- 5.5
   # aliased to a recent 5.6.x version
   - 5.6
   # aliased to a recent 7.0.x version
@@ -14,9 +14,9 @@ php:
   # aliased to a recent 7.1.x version
   - 7.1
   # aliased to a recent 7.2.x version
-  - 7.2
+  #- 7.2
   # aliased to a recent nightly build
-  - nightly
+  #- nightly
   # aliased to a recent hhvm version
   - hhvm
 
@@ -31,7 +31,7 @@ matrix:
     - php: hhvm
       env: DB=pgsql  # PDO driver for pgsql is unsupported by HHVM (3rd party install for support)
   allow_failures:
-    - php: 5.5
+    - php: 7.1
     - php: hhvm
 
 # execute any number of scripts before the test run, custom env's are available as variables

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,8 @@ language: php
 php:
   # using major version aliases
 
-  # aliased to 5.2.17
-  #- 5.2
-  # aliased to 5.3.29
-  #- 5.3
   # aliased to a recent 5.4.x version
-  #- 5.4
+  - 5.4
   # aliased to a recent 5.5.x version
   - 5.5
   # aliased to a recent 5.6.x version
@@ -31,6 +27,8 @@ matrix:
     - php: hhvm
       env: DB=pgsql  # PDO driver for pgsql is unsupported by HHVM (3rd party install for support)
   allow_failures:
+    - php: 5.2
+    - php: 5.3
     - php: 7.0
     - php: hhvm
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ php:
   # using major version aliases
 
   # aliased to 5.2.17
-  - 5.2
+  #- 5.2
   # aliased to 5.3.29
-  - 5.3
+  #- 5.3
   # aliased to a recent 5.4.x version
-  - 5.4
+  #- 5.4
   # aliased to a recent 5.5.x version
   - 5.5
   # aliased to a recent 5.6.x version

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ continuous integration with a PHP project.
 
 Here is a sample status icon showing the state of the master branch.
 
-[![Build Status](https://travis-ci.org/codesport/php-example.svg?branch=master)](https://travis-ci.org/codesport/php-example)
+[![Build Status](https://travis-ci.org/travis-ci-examples/php-example.svg?branch=master)](https://travis-ci.org/travis-ci-examples/php-example)
 
 In order to run this project just fork it on github.com and then [enable](http://about.travis-ci.org/docs/user/getting-started/)
 your fork on your [travis-ci profile](http://travis-ci.org/profile). Every push will then trigger a new build on Travis CI.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ continuous integration with a PHP project.
 
 Here is a sample status icon showing the state of the master branch.
 
-[![Build Status](https://travis-ci.org/travis-ci-examples/php.svg?branch=master)](https://travis-ci.org/travis-ci-examples/php)
+[![Build Status](https://travis-ci.org/codesport/php-example.svg?branch=master)](https://travis-ci.org/codesport/php-example)
 
 In order to run this project just fork it on github.com and then [enable](http://about.travis-ci.org/docs/user/getting-started/)
 your fork on your [travis-ci profile](http://travis-ci.org/profile). Every push will then trigger a new build on Travis CI.

--- a/Tests/HelloWorldTest.php
+++ b/Tests/HelloWorldTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class HelloWorldTest extends PHPUnit_Framework_TestCase
+class HelloWorldTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var PDO
@@ -44,4 +44,3 @@ class HelloWorldTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Bar', $helloWorld->what());
     }
 }
-

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -2,6 +2,12 @@
 
 function loader($class)
 {
+    // Support for pre-PHP 5.6 versions
+    if ($class === 'PHPUnit\Framework\TestCase') {
+      class_alias('PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
+
+      return;
+    }
     $file = $class . '.php';
     if (file_exists($file)) {
         require $file;


### PR DESCRIPTION
Heads up:  

(1) PHP 5.2 and 5.3 no longer passed the tests in your example. So, these were moved to "allow_failures" in the .travis.yml file.

(2) Updated the URLs of the SVG and your profile page in README.md to reflect their current locations at https://travis-ci.org.  

Thanks